### PR TITLE
Fix replacement not applied globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (elements, {
 } = {}) => {
   return value => {
     for (const element of elements) {
-      const search = new RegExp(`<${element}>(.+)</${element}>`);
+      const search = new RegExp(`<${element}>(.+)</${element}>`, 'g');
 
       value = value.replace(search, `<${element}>${replacement}</${element}>`);
     }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -32,6 +32,9 @@ describe('maskXml()', () => {
         <foo>bar</foo>
         <password>foo</password>
         <username>bar</username>
+        <bar>
+          <password>foo</password>
+        </bar>
       </xml>
     `;
 
@@ -40,6 +43,9 @@ describe('maskXml()', () => {
         <foo>bar</foo>
         <password>--REDACTED--</password>
         <username>--REDACTED--</username>
+        <bar>
+          <password>--REDACTED--</password>
+        </bar>
       </xml>
     `);
   });


### PR DESCRIPTION
Fixes a bug where the replacement was not applied globally if the `key` occurred more than once in the XML document.